### PR TITLE
Support control over compression

### DIFF
--- a/src/bin/catprint.rs
+++ b/src/bin/catprint.rs
@@ -45,6 +45,10 @@ struct Print {
     /// Rotate picture by 90 degrees
     #[clap(short, long)]
     rotate: bool,
+
+    /// Don't use compression
+    #[clap(long)]
+    no_compress: bool,
 }
 
 #[derive(ArgEnum)]
@@ -112,7 +116,8 @@ async fn main_print(mut device: device::Device, print: Print) -> Result<(), Box<
         _ => protocol::DrawingMode::Image,
     };
 
-    let print = image.print(mode, quality, energy);
+    let use_compression = device.supports_compression() && !print.no_compress;
+    let print = image.print(mode, quality, energy, use_compression);
 
     device.queue_commands(&print);
     device.queue_command(protocol::Command::Feed(

--- a/src/device.rs
+++ b/src/device.rs
@@ -11,6 +11,7 @@ const TX_CHARACTERISTIC_UUID: Uuid = Uuid::from_u128(0x0000ae01_0000_1000_8000_0
 #[derive(Debug)]
 pub struct Device {
     peripheral: btleplug::platform::Peripheral,
+    supports_compression: bool,
     tx_buffer: VecDeque<u8>,
 }
 
@@ -41,9 +42,16 @@ impl Device {
                                 peripheral.connect().await?;
                             }
                             let _ = peripheral.discover_characteristics().await?;
+
+                            let supports_compression = match name {
+                                "MX10" => false,
+                                _ => true,
+                            };
+
                             device_result = Ok(Device {
                                 peripheral,
                                 tx_buffer: VecDeque::new(),
+                                supports_compression,
                             });
                             break;
                         }
@@ -108,5 +116,9 @@ impl Device {
 
     pub async fn destroy(self) {
         self.peripheral.disconnect().await.unwrap();
+    }
+
+    pub fn supports_compression(&self) -> bool {
+        self.supports_compression
     }
 }


### PR DESCRIPTION
I recently bought one of the printers from [this store](https://www.aliexpress.com/item/1005006351632691.html?spm=a2g0o.order_list.order_list_main.35.63961802lzG8lQ). It identifies itself as MX10. When I initially tried printing it came out garbled but when I disabled compression all was well.

This PR adds a CLI option to allow compression to be disabled—useful for testing unknown devices that don't support it. It also disables compression by default for devices that are known not to support it (for now MX10).